### PR TITLE
GameSceneに平行光源の編集機能を追加

### DIFF
--- a/GameProject/GameScene/GameScene.cpp
+++ b/GameProject/GameScene/GameScene.cpp
@@ -5,8 +5,18 @@
 #include "Object3dBasic.h"
 #include <Type/Singleton.h>
 #include "SpriteBasic.h"
+#include "ImGuiManager.h"
+
 
 void GameScene::Initialize() {
+
+    directLightParam_ = {
+        .direction = { 0.0f, -1.0f, 0.0f },
+        .color = { 1.0f, 1.0f, 1.0f, 1.0f },
+        .lightType = 1,
+        .intensity = 2.0f
+    };
+
     ModelManager::GetInstance()->LoadModel("AnimatedCube.gltf");
     pCollisionManager_ = Singleton<CollisionManager>::GetInstance();
 
@@ -55,6 +65,8 @@ void GameScene::Finalize() {
 }
 
 void GameScene::Update() {
+    Object3dBasic::GetInstance()->SetDirectionalLight(directLightParam_.direction, directLightParam_.color, directLightParam_.lightType, directLightParam_.intensity);
+
     terrain_->Update();
 
     player_->Update();
@@ -101,4 +113,10 @@ void GameScene::DrawImGui() {
 	enemy_->ImGui();
     enemyManager_.ImGui();
     camera_->ImGui();
+
+    ImGui::Begin("Directional Light");
+    ImGui::DragFloat3("Direction", &directLightParam_.direction.x, 0.01f);
+    ImGui::ColorEdit4("Color", &directLightParam_.color.x);
+    ImGui::DragFloat("Intensity", &directLightParam_.intensity, 0.01f);
+    ImGui::End();
 }

--- a/GameProject/GameScene/GameScene.h
+++ b/GameProject/GameScene/GameScene.h
@@ -26,6 +26,15 @@ class GameScene : public BaseScene {
     std::unique_ptr<Terrain> terrain_;
 	EnemyManager enemyManager_;
 
+public:
+    struct DirectionalLightParam {
+        Vector3 direction;
+        Vector4 color;
+        int32_t lightType;
+        float intensity;
+    };
+
+    DirectionalLightParam directLightParam_;
 
 public:
     void Initialize() override;

--- a/GameProject/GameScene/Object/Terrain/Terrain.cpp
+++ b/GameProject/GameScene/Object/Terrain/Terrain.cpp
@@ -16,7 +16,7 @@ void Terrain::Initialize()
     object_->SetTranslate(transform_.translate);
     object_->SetMaterialColor(Vector4(0.1f, 0.1f, 0.1f, 1.0f));
     object_->SetEnableLighting(true);
-    object_->SetEnableHighlight(true);
+    object_->SetEnableHighlight(false);
 }
 
 void Terrain::Update()

--- a/GameProject/imgui.ini
+++ b/GameProject/imgui.ini
@@ -53,3 +53,8 @@ Pos=60,60
 Size=91,64
 Collapsed=0
 
+[Window][Directional Light]
+Pos=60,60
+Size=339,122
+Collapsed=0
+


### PR DESCRIPTION
- `GameScene.cpp`に`ImGuiManager.h`のインクルードを追加
- `GameScene::Initialize`で`directLightParam_`を初期化し、`AnimatedCube.gltf`モデルをロード
- `GameScene::Update`で`Object3dBasic`に方向性ライトのパラメータを設定
- `GameScene::DrawImGui`で方向性ライトのパラメータを編集できるImGuiウィンドウを追加
- `GameScene.h`に`DirectionalLightParam`構造体と`directLightParam_`メンバ変数を追加
- `Terrain.cpp`で`object_`のハイライトを無効化
- `imgui.ini`で`Directional Light`ウィンドウの位置とサイズを設定し、展開状態を記録