### PR TITLE
GUI_ChainとNiUIの機能追加と改善

### DIFF
--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -195,6 +195,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="GameScene\System\ChainManager.cpp" />
     <ClCompile Include="GameSystem\DeltaTimeManager\DeltaTimeManager.cpp" />
     <ClCompile Include="GameSystem\StageManager\StageManager.cpp" />
+    <ClCompile Include="GameUI\Chain\GUI_Chain.cpp" />
     <ClCompile Include="GameUI\LvUP\GUI_LvUP.cpp" />
     <ClCompile Include="GameUI\PauseMenu\GUI_PauseMenu.cpp" />
     <ClCompile Include="Internal\SingletonFinalizer.cpp" />
@@ -238,6 +239,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="GameScene\System\ChainManager.h" />
     <ClInclude Include="GameSystem\DeltaTimeManager\DeltaTimeManager.h" />
     <ClInclude Include="GameSystem\StageManager\StageManager.h" />
+    <ClInclude Include="GameUI\Chain\GUI_Chain.h" />
     <ClInclude Include="GameUI\PauseMenu\GUI_PauseMenu.h" />
     <ClInclude Include="Internal\SingletonFinalizer.h" />
     <ClInclude Include="GameScene\Object\Collision\LimitedCollider.h" />

--- a/GameProject/GameProject.vcxproj.filters
+++ b/GameProject/GameProject.vcxproj.filters
@@ -101,6 +101,9 @@
     <Filter Include="GameSystem\DeltaTimeManager">
       <UniqueIdentifier>{ef59b76f-0256-417b-918b-f78dda01e8ac}</UniqueIdentifier>
     </Filter>
+    <Filter Include="GameUI\Chain">
+      <UniqueIdentifier>{a7116316-41be-4eed-af7c-d3520105b73c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
@@ -222,6 +225,7 @@
     <ClCompile Include="GameScene\Object\Object.cpp">
       <Filter>Object</Filter>
     </ClCompile>
+    <ClCompile Include="GameUI\Chain\GUI_Chain.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="NiUI\NiUI.h">
@@ -356,5 +360,8 @@
       <Filter>GameSystem\DeltaTimeManager</Filter>
     </ClInclude>
     <ClInclude Include="GameScene\Object\Collision\LimitedCollider.h" />
+    <ClInclude Include="GameUI\Chain\GUI_Chain.h">
+      <Filter>GameUI\Chain</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/GameProject/GameScene/GameScene.cpp
+++ b/GameProject/GameScene/GameScene.cpp
@@ -41,10 +41,12 @@ void GameScene::Initialize() {
 
     guiLvUP_ = std::make_unique<GUI_LvUP>();
     guiPauseMenu_ = std::make_unique<GUI_PauseMenu>();
+    guiChain_ = std::make_unique<GUI_Chain>();
 
     // Observer登録
     player_->AddObserver(guiLvUP_.get());
     player_->AddObserver(guiPauseMenu_.get());
+    player_->AddObserver(guiChain_.get());
 
     // Minimap
     minimap_ = make_unique<Minimap>();
@@ -89,6 +91,7 @@ void GameScene::Update() {
 
     guiLvUP_->Update();
     guiPauseMenu_->Update();
+    guiChain_->Update();
 
 	boss_->Update();
 	enemyManager_->Update();
@@ -129,6 +132,7 @@ void GameScene::DrawImGui() {
     enemyManager_->ImGui();
     boss_->ImGui();
     camera_->ImGui();
+    guiChain_->ImGui();
 
     ImGui::Begin("Directional Light");
     ImGui::DragFloat3("Direction", &directLightParam_.direction.x, 0.01f);

--- a/GameProject/GameScene/GameScene.h
+++ b/GameProject/GameScene/GameScene.h
@@ -4,6 +4,7 @@
 #include "BaseScene.h"
 #include <GameUI/LvUP/GUI_LvUP.h>
 #include <GameUI/PauseMenu/GUI_PauseMenu.h>
+#include <GameUI/Chain/GUI_Chain.h>
 
 #include "HUD/Minimap.h"
 #include "Object/Camera/FollowCamera.h"
@@ -19,6 +20,8 @@ class GameScene : public BaseScene {
     std::unique_ptr<FollowCamera> camera_;
     std::unique_ptr<GUI_LvUP> guiLvUP_;
     std::unique_ptr<GUI_PauseMenu> guiPauseMenu_;
+    std::unique_ptr<GUI_Chain> guiChain_;
+
     std::unique_ptr<Minimap> minimap_; 
     CollisionManager* pCollisionManager_ = nullptr;
 	std::unique_ptr<Boss>boss_;

--- a/GameProject/GameScene/Object/Player/Player.cpp
+++ b/GameProject/GameScene/Object/Player/Player.cpp
@@ -114,6 +114,13 @@ void Player::UpdateInputCommands()
             observer->OnNotify("toggle_lvup");
         }
     }
+    if (pInput_->TriggerKey(DIK_C))
+    {
+        for (auto observer : observers_)
+        {
+            observer->OnNotify("toggle_chain");
+        }
+    }
 
     // Perspective
     transform_.rotate.y += static_cast<float>(Input::GetInstance()->PushKey(DIK_RIGHTARROW) - Input::GetInstance()->PushKey(DIK_LEFTARROW)) * 0.03f;

--- a/GameProject/GameUI/Chain/GUI_Chain.cpp
+++ b/GameProject/GameUI/Chain/GUI_Chain.cpp
@@ -1,0 +1,54 @@
+#include "GUI_Chain.h"
+
+#include <NiUI/NiUI.h>
+#include <imgui.h>
+
+void GUI_Chain::OnNotify(const std::string& _event)
+{
+    if (_event == "open_chain")
+    {
+        isDisplay_ = true;
+    }
+    else if (_event == "close_chain")
+    {
+        isDisplay_ = false;
+    }
+    else if (_event == "toggle_chain")
+    {
+        isDisplay_ = !isDisplay_;
+    }
+}
+
+void GUI_Chain::Update()
+{
+    /// 通知されたら表示する
+    if (isDisplay_)
+    {
+        ShowChain();
+    }
+}
+
+void GUI_Chain::ImGui()
+{
+    ImGui::Begin("Chain Display");
+    ImGui::Checkbox("Display", &isDisplay_);
+    ImGui::Text("Area1 : %s", area1_.c_str());
+    ImGui::Text("Area2 : %s", area2_.c_str());
+    ImGui::Text("Area3 : %s", area3_.c_str());
+    ImGui::End();
+}
+
+void GUI_Chain::ShowChain()
+{
+    auto center = NiUI_StandardPoint::Center;
+    if (NiUI::BeginDiv("Chain", TEXTUREPATH_, NiUI::WHITE, { 0, 0 }, { 800, 450 }, center, center))
+    {
+        area1_ = NiUI::DragItemArea("DragItemArea1", TEXTUREPATH_, NiUI::BLUE, { -240, 150 }, { 120, 120 }, center, center);
+        area2_ = NiUI::DragItemArea("DragItemArea2", TEXTUREPATH_, NiUI::BLUE, { 0, 150 }, { 120, 120 }, center, center);
+        area3_ = NiUI::DragItemArea("DragItemArea3", TEXTUREPATH_, NiUI::BLUE, { 240, 150 }, { 120, 120 }, center, center);
+        NiUI::DragItem("Yellow", TEXTUREPATH_, NiUI::YELLOW, { -240, -150 }, { 100, 100 }, center, center);
+        NiUI::DragItem("Cian", TEXTUREPATH_, NiUI::CIAN, { 0, -150 }, { 100, 100 }, center, center);
+        NiUI::DragItem("Magenta", TEXTUREPATH_, NiUI::MAGENTA, { 240, -150 }, { 100, 100 }, center, center);
+        NiUI::EndDiv();
+    }
+}

--- a/GameProject/GameUI/Chain/GUI_Chain.h
+++ b/GameProject/GameUI/Chain/GUI_Chain.h
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <string> // std::string
-
 #include <Interfaces/IObserver.h>
+#include <string>
 
-class GUI_LvUP : public IObserver
+class GUI_Chain : public IObserver
 {
 public:
-    GUI_LvUP() = default;
-    ~GUI_LvUP() = default;
+    GUI_Chain() = default;
+    ~GUI_Chain() = default;
 
     // 通知する
     void OnNotify(const std::string& _event) override;
@@ -18,17 +17,13 @@ public:
     void ImGui();
 
 private:
-    // レベルアップ画面を表示する
-    void ShowLvUP();
-
-
-private:
     const std::string TEXTUREPATH_ = "white.png";
-
-    // レベルアップ画面を表示するかどうか
     bool isDisplay_ = false;
-
     std::string area1_ = "";
     std::string area2_ = "";
     std::string area3_ = "";
+
+private:
+    // チェイン画面を表示する
+    void ShowChain();
 };

--- a/GameProject/GameUI/LvUP/GUI_LvUP.cpp
+++ b/GameProject/GameUI/LvUP/GUI_LvUP.cpp
@@ -1,9 +1,8 @@
 #include "GUI_LvUP.h"
 
 #include <NiUI/NiUI.h>
-#include <cassert>
 
-#include <Audio.h>
+#include <imgui.h>
 
 void GUI_LvUP::OnNotify(const std::string& _event)
 {
@@ -28,6 +27,11 @@ void GUI_LvUP::Update()
     {
         ShowLvUP();
     }
+}
+
+void GUI_LvUP::ImGui()
+{
+
 }
 
 void GUI_LvUP::ShowLvUP()
@@ -55,13 +59,6 @@ void GUI_LvUP::ShowLvUP()
         }
         NiUI::EndDiv();
     }
-
-    NiUI::DragItemArea("DragItemArea1", TEXTUREPATH_, NiUI::BLUE, { -240, 150 }, { 120, 120 }, center, center);
-    NiUI::DragItemArea("DragItemArea2", TEXTUREPATH_, NiUI::BLUE, { 0, 150 }, { 120, 120 }, center, center);
-    NiUI::DragItemArea("DragItemArea3", TEXTUREPATH_, NiUI::BLUE, { 240, 150 }, { 120, 120 }, center, center);
-    NiUI::DragItem("DragItem1", TEXTUREPATH_, NiUI::YELLOW, { -240, -150 }, { 100, 100 }, center, center);
-    NiUI::DragItem("DragItem2", TEXTUREPATH_, NiUI::CIAN, { 0, -150 }, { 100, 100 }, center, center);
-    NiUI::DragItem("DragItem3", TEXTUREPATH_, NiUI::MAGENTA, { 240, -150 }, { 100, 100 }, center, center);
 
 
     if (isClose)

--- a/GameProject/MyGame/MyGame.cpp
+++ b/GameProject/MyGame/MyGame.cpp
@@ -68,9 +68,10 @@ void MyGame::Initialize()
     NiUI::SetConfirmSound(Audio::GetInstance()->LoadWaveFile("ui_confirm.wav"));
 
     /// デバッグUIの設定
-    auto& io = NiUI::GetIO();
-    auto& state = NiUI::GetState();
-    niUI_Debug_ = std::make_unique<NiUI_Debug>(io, state);
+    niUI_Debug_ = std::make_unique<NiUI_Debug>();
+    niUI_Debug_->SetIO(&NiUI::GetIO());
+    niUI_Debug_->SetState(&NiUI::GetState());
+    niUI_Debug_->SetSetting(&NiUI::GetSetting());
     NiUI::SetDebug(niUI_Debug_.get());
 
     /// StageManagerの初期化

--- a/GameProject/NiUI/Derived/NiUI_Debug.cpp
+++ b/GameProject/NiUI/Derived/NiUI_Debug.cpp
@@ -15,28 +15,39 @@ void NiUI_Debug::DrawDebugUI()
         return;
     }
 
+    if (ImGui::TreeNodeEx("Setting", parentFlags))
+    {
+        if (ImGui::TreeNode("Buffer Setting"))
+        {
+            ImGui::InputInt("Delete Element Threshold", &(setting_->deleteElementThreshold));
+            ImGui::TreePop();
+        }
+        ImGui::TreePop();
+    }
+
     if (ImGui::TreeNodeEx("State", parentFlags))
     {
         if (ImGui::TreeNode("Validation"))
         {
-            ImGui::Text("isInitialized : %s", state_.valid.isInitialized ? "true" : "false");
-            ImGui::Text("isBeginFrame : %s", state_.valid.isBeginFrame ? "true" : "false");
-            ImGui::Text("nestCount : %d", state_.valid.nestCount);
+            ImGui::Text("isInitialized : %s", state_->valid.isInitialized ? "true" : "false");
+            ImGui::Text("isBeginFrame : %s", state_->valid.isBeginFrame ? "true" : "false");
+            ImGui::Text("nestCount : %d", state_->valid.nestCount);
             ImGui::TreePop();
         }
         if (ImGui::TreeNode("ComponentID"))
         {
-            ImGui::Text("Type : %s", state_.componentID.type.c_str());
-            ImGui::Text("ActiveComponentID : %s", state_.componentID.active.c_str());
-            ImGui::Text("HoverComponentID : %s", state_.componentID.hover.c_str());
-            ImGui::Text("PreHoverComponentID : %s", state_.componentID.preHover.c_str());
-            ImGui::Text("PreActiveComponentID : %s", state_.componentID.preActive.c_str());
+            ImGui::Text("TypeHover : %s", state_->componentID.typeHover.c_str());
+            ImGui::Text("TypeActive : %s", state_->componentID.typeActive.c_str());
+            ImGui::Text("ActiveComponentID : %s", state_->componentID.active.c_str());
+            ImGui::Text("HoverComponentID : %s", state_->componentID.hover.c_str());
+            ImGui::Text("PreHoverComponentID : %s", state_->componentID.preHover.c_str());
+            ImGui::Text("PreActiveComponentID : %s", state_->componentID.preActive.c_str());
             ImGui::TreePop();
         }
         if (ImGui::TreeNode("Time"))
         {
-            ImGui::Text("HoverTime : %d", state_.time.hover);
-            ImGui::Text("ActiveTime : %d", state_.time.active);
+            ImGui::Text("HoverTime : %d", state_->time.hover);
+            ImGui::Text("ActiveTime : %d", state_->time.active);
             ImGui::TreePop();
         }
         ImGui::TreePop();
@@ -46,21 +57,21 @@ void NiUI_Debug::DrawDebugUI()
     {
         if (ImGui::TreeNode("InputData"))
         {
-            ImGui::Text("CursorPos : (%.2f, %.2f)", io_.input.cursorPos.x, io_.input.cursorPos.y);
-            ImGui::Text("TriggeredPos : (%.2f, %.2f)", io_.input.triggeredPos.x, io_.input.triggeredPos.y);
-            ImGui::Text("DifferencePos : (%.2f, %.2f)", io_.input.differencePos.x, io_.input.differencePos.y);
-            ImGui::Text("isLeft : %s", io_.input.isLeft ? "true" : "false");
-            ImGui::Text("isLeftPre : %s", io_.input.isLeftPre ? "true" : "false");
-            ImGui::Text("isRight : %s", io_.input.isRight ? "true" : "false");
-            ImGui::Text("isRightPre : %s", io_.input.isRightPre ? "true" : "false");
-            ImGui::Text("isMiddle : %s", io_.input.isMiddle ? "true" : "false");
-            ImGui::Text("isMiddlePre : %s", io_.input.isMiddlePre ? "true" : "false");
+            ImGui::Text("CursorPos : (%.2f, %.2f)", io_->input.cursorPos.x, io_->input.cursorPos.y);
+            ImGui::Text("TriggeredPos : (%.2f, %.2f)", io_->input.triggeredPos.x, io_->input.triggeredPos.y);
+            ImGui::Text("DifferencePos : (%.2f, %.2f)", io_->input.differencePos.x, io_->input.differencePos.y);
+            ImGui::Text("isLeft : %s", io_->input.isLeft ? "true" : "false");
+            ImGui::Text("isLeftPre : %s", io_->input.isLeftPre ? "true" : "false");
+            ImGui::Text("isRight : %s", io_->input.isRight ? "true" : "false");
+            ImGui::Text("isRightPre : %s", io_->input.isRightPre ? "true" : "false");
+            ImGui::Text("isMiddle : %s", io_->input.isMiddle ? "true" : "false");
+            ImGui::Text("isMiddlePre : %s", io_->input.isMiddlePre ? "true" : "false");
             ImGui::TreePop();
         }
         if (ImGui::TreeNode("AudioHandle"))
         {
-            ImGui::Text("ButtonHover : %d", io_.audioHnd.buttonHover);
-            ImGui::Text("ButtonConfirm : %d", io_.audioHnd.buttonConfirm);
+            ImGui::Text("ButtonHover : %d", io_->audioHnd.buttonHover);
+            ImGui::Text("ButtonConfirm : %d", io_->audioHnd.buttonConfirm);
             ImGui::TreePop();
         }
         ImGui::TreePop();

--- a/GameProject/NiUI/Derived/NiUI_Debug.h
+++ b/GameProject/NiUI/Derived/NiUI_Debug.h
@@ -1,10 +1,10 @@
-﻿#pragma once
+#pragma once
 
 #include "../Interface/NiUI_IDebug.h"
 
 class NiUI_Debug : public INiUIDebug
 {
 public:
-    NiUI_Debug(const NiUIIO& _io, const NiUICoreState& _state) : INiUIDebug(_io, _state) {}
+    NiUI_Debug() = default;
     void DrawDebugUI();
 };

--- a/GameProject/NiUI/Impl/Impl_Button.cpp
+++ b/GameProject/NiUI/Impl/Impl_Button.cpp
@@ -50,18 +50,7 @@ NiUI_ButtonState NiUI::Button(
 
 bool NiUI::ButtonBehavior(const std::string& _id, const NiUI_InputState& _inputState, bool& _out_held)
 {
-    if (_inputState.isHover)
-    {
-        state_.componentID.type = "Button";
-        state_.componentID.hover = _id;
-    }
-
-
-    if(_inputState.isTrigger)
-    {
-        state_.componentID.type = "Button";
-        state_.componentID.active = _id;
-    }
+    SetComponentId(_inputState, _id, "Button");
 
 
     if(state_.componentID.active == _id)

--- a/GameProject/NiUI/Impl/Impl_Div.cpp
+++ b/GameProject/NiUI/Impl/Impl_Div.cpp
@@ -100,16 +100,7 @@ void NiUI::DivBehavior(const std::string& _id, bool _isHover, bool _isTrigger)
     // ネストカウントを増やす
     state_.valid.nestCount++;
 
-    if (_isHover)
-    {
-        state_.componentID.hover = _id;
-        state_.componentID.type = "Div";
-    }
-
-    if (_isTrigger)
-    {
-        state_.componentID.active = _id;
-    }
+    SetComponentId({ .isHover = _isHover, .isTrigger = _isTrigger }, _id, "Div");
 }
 
 void NiUI::DivDataEnqueue()

--- a/GameProject/NiUI/Impl/Impl_DragItem.cpp
+++ b/GameProject/NiUI/Impl/Impl_DragItem.cpp
@@ -17,7 +17,7 @@ std::string NiUI::DragItemArea(const std::string & _id, const std::string & _tex
     JudgeClickRect(transformEx.position, transformEx.size, istate);
 
     /// 挙動
-    DragItemAreaBehavior(_id, istate.isHover, istate.isTrigger, transformEx, _position);
+    std::string result = DragItemAreaBehavior(_id, istate.isHover, istate.isTrigger, transformEx, _position);
 
     auto& areaData = dragItemAreaData_[_id];
     areaData.id = _id;
@@ -27,35 +27,32 @@ std::string NiUI::DragItemArea(const std::string & _id, const std::string & _tex
     areaData.size = _size;
     areaData.zOrder = state_.buffer.currentZOrder++;
 
-    return {};
+    return result;
 }
 
 std::string NiUI::DragItemAreaBehavior(const std::string& _id, bool _isHover, bool _isTrigger, NiUI_Transform2dEx& _transform, const NiVec2& _leftTop)
 {
-    if (_isHover)
+    SetComponentId({ .isHover = _isHover, .isTrigger = _isTrigger }, _id, "DragItemArea");
+
+    auto item = state_.buffer.areaToItem.find(_id);
+    if (item != state_.buffer.areaToItem.end())
     {
-        state_.componentID.hover = _id;
-        state_.componentID.type = "DragItemArea";
+        return item->second;
     }
-    return {};
+    else
+    {
+        return {};
+    }
+    
 }
 
 std::string NiUI::DragItemBehavior(const std::string& _id, const NiUI_InputState& _inputState, NiUI_Transform2dEx& _transform, const NiVec2& _originLeftTop)
 {
     std::string preHoverId = state_.componentID.hover;
-    std::string preTypeId = state_.componentID.type;
+    std::string preTypeId = state_.componentID.typeHover;
     std::string result = {};
 
-    if (_inputState.isHover)
-    {
-        state_.componentID.hover = _id;
-        state_.componentID.type = "DragItem";
-    }
-
-    if (_inputState.isTrigger)
-    {
-        state_.componentID.active = _id;
-    }
+    SetComponentId(_inputState, _id, "DragItem");
 
     /// offsetの更新
     auto& offset = dragItemOffset_[_id];
@@ -64,13 +61,26 @@ std::string NiUI::DragItemBehavior(const std::string& _id, const NiUI_InputState
 
     if (_inputState.isRelease && state_.componentID.active == _id) 
     {
-        if (preTypeId == "DragItemArea")
+        for (auto& areaToItem : state_.buffer.areaToItem)
+        {
+            if (areaToItem.second == _id)
+            {
+                areaToItem.second = {};
+            }
+        }
+        if (preTypeId == "DragItemArea" && (state_.buffer.areaToItem[preHoverId].empty() || state_.buffer.areaToItem[preHoverId] == _id))
         {
             const auto& area = dragItemAreaData_[preHoverId];
             NiVec2 diff = area.size - _transform.size;
             _transform.position = area.leftTop + diff * 0.5f;
             offset = _transform.position - _originLeftTop;
+            state_.buffer.areaToItem[preHoverId] = _id;
             result = preHoverId;
+        }
+        else if (preTypeId != "DragItemArea")
+        {
+            _transform.position = _originLeftTop;
+            offset = {};
         }
         else
         {

--- a/GameProject/NiUI/Interface/NiUI_IDebug.h
+++ b/GameProject/NiUI/Interface/NiUI_IDebug.h
@@ -5,10 +5,14 @@
 class INiUIDebug
 {
 public:
-    INiUIDebug(const NiUIIO& _io, const NiUICoreState& _state) : io_(_io) , state_(_state){}
+    INiUIDebug() = default;
     virtual void DrawDebugUI() = 0;
+    void SetIO(const NiUIIO* _io) { io_ = _io; }
+    void SetState(const NiUICoreState* _state) { state_ = _state; }
+    void SetSetting(NiUISetting* _setting) { setting_ = _setting; }
 
 protected:
-    const NiUIIO& io_;
-    const NiUICoreState& state_;
+    const NiUIIO* io_ = nullptr;
+    const NiUICoreState* state_ = nullptr;
+    NiUISetting* setting_ = nullptr;
 };

--- a/GameProject/NiUI/NiUI.cpp
+++ b/GameProject/NiUI/NiUI.cpp
@@ -1,6 +1,7 @@
 #include "NiUI.h"
 
 #include <stdexcept> // runtime_error
+#include <cassert>
 
 NiUI_Input          NiUI::input_        = NiUI_Input();
 NiVec2              NiUI::leftTop_      = { 0, 0 };
@@ -10,6 +11,7 @@ IDrawer*            NiUI::drawer_       = nullptr;
 NiUIIO              NiUI::io_           = NiUIIO();
 NiUICoreState       NiUI::state_        = NiUICoreState();
 INiUIDebug*         NiUI::debug_        = nullptr;
+NiUISetting         NiUI::setting_      = NiUISetting();
 NiUIStyle           NiUI::style_        = NiUIStyle();
 
 const NiVec4        NiUI::WHITE         = { 1.0f, 1.0f, 1.0f, 1.0f };
@@ -39,10 +41,13 @@ void NiUI::Initialize(const NiVec2& _size, const NiVec2& _leftTop)
 
     input_.Initialize();
 
+    setting_.deleteElementThreshold = 35;
+
     style_.windowPadding = { 10, 10 };
     style_.itemSpacing = { 10, 10 };
     style_.divPadding = { 10, 10 };
     style_.color.backGround = { 0.0f, 0.0f, 0.0f, 0.7f };
+
 
     return;
 }
@@ -68,7 +73,7 @@ void NiUI::DrawUI()
     // 描画処理に必要なデータの確認
     CheckValid_DrawUI();
 
-    // ボタンの確定処理
+    // コンポーネントの確定処理
     PostProcessComponents();
 
     // コンポーネントの描画データを追加
@@ -249,11 +254,32 @@ void NiUI::ClearData()
     dragItemAreaData_.clear();
     dragItemData_.clear();
 
-    state_.componentID.hover = {};
-    state_.componentID.type = {};
+    auto& cid = state_.componentID;
+    auto& buffer = state_.buffer;
 
-    state_.buffer.currentRegion = nullptr;
-    state_.buffer.currentZOrder = 0;
+    cid.hover = {};
+    cid.typeHover = {};
+
+    buffer.currentRegion = nullptr;
+    buffer.currentZOrder = 0;
+
+    if (buffer.areaToItem.size() > setting_.deleteElementThreshold)
+    {
+        std::vector<std::string> deleteKeys;
+        for (auto& areaToItem : buffer.areaToItem)
+        {
+            if (areaToItem.second.empty())
+            {
+                deleteKeys.push_back(areaToItem.first);
+            }
+        }
+        for (auto& key : deleteKeys)
+        {
+            buffer.areaToItem.erase(key);
+        }
+        if (buffer.areaToItem.size() > setting_.deleteElementThreshold) setting_.deleteElementThreshold *= 2;
+    }
+    
     return;
 }
 
@@ -307,6 +333,22 @@ void NiUI::OffsetUpdate(
     }
 }
 
+void NiUI::SetComponentId(const NiUI_InputState& _inputState, const std::string& _id, const std::string& _type)
+{
+    if (_id.empty()) assert(false && "unexpected");
+
+    if (_inputState.isHover)
+    {
+        state_.componentID.hover = _id;
+        state_.componentID.typeHover = _type;
+    }
+    if (_inputState.isTrigger)
+    {
+        state_.componentID.active = _id;
+        state_.componentID.typeActive = _type;
+    }
+}
+
 void NiUI::PostProcessComponents()
 {
     auto& componentID = state_.componentID;
@@ -315,6 +357,7 @@ void NiUI::PostProcessComponents()
     if (!io_.input.isLeft && io_.input.isLeftPre)
     {
         componentID.active = {};
+        componentID.typeActive = {};
     }
 
     /// =========
@@ -334,6 +377,48 @@ void NiUI::PostProcessComponents()
         componentTime.active = 0;
     }
 
+    if (componentID.typeActive == "DragItem" && !componentID.active.empty())
+    {
+        int max = state_.buffer.currentZOrder - 1;
+        int missingIndex = 0;
+        int currentIndex = 0;
+        StringMap<int> newZMap;
+
+        for (auto itr = dragItemData_.begin(); itr != dragItemData_.end(); ++itr)
+        {
+            auto& current = itr->second;
+            auto& missing = std::next(dragItemData_.begin(), missingIndex)->second;
+
+            if (current.zOrder < dragItemData_[componentID.active].zOrder)
+            {
+                newZMap[current.id] = current.zOrder;
+                ++currentIndex;
+                continue;
+            }
+
+            if (currentIndex == 0)
+            {
+                newZMap[current.id] = current.zOrder;
+            }
+            else if (current.zOrder > missing.zOrder)
+            {
+                newZMap[current.id] = missing.zOrder;
+                missingIndex = currentIndex;
+            }
+            else
+            {
+                newZMap[current.id] = newZMap[missing.id];
+                newZMap[missing.id] = current.zOrder;
+            }
+            ++currentIndex;
+        }
+
+        newZMap[componentID.active] = max;
+        for (auto& itr : newZMap)
+        {
+            dragItemData_[itr.first].zOrder = itr.second;
+        }
+    }
 
     /// ========
     /// Hover
@@ -360,7 +445,7 @@ void NiUI::PlaySE(const std::string& _type, uint32_t _hoverSE, uint32_t _confirm
     auto& componentID = state_.componentID;
     auto& componentTime = state_.time;
 
-    if (componentID.type != _type) return;
+    if (componentID.typeHover != _type) return;
 
     if (componentTime.active == 0 && componentID.preActive == componentID.preHover && !componentID.preActive.empty())
     {

--- a/GameProject/NiUI/NiUI.h
+++ b/GameProject/NiUI/NiUI.h
@@ -125,6 +125,7 @@ public: /// セッター
 public: /// ゲッター
     static const NiUIIO& GetIO() { return io_; }
     static const NiUICoreState& GetState() { return state_; }
+    static NiUISetting& GetSetting() { return setting_; }
     static const NiUIStyle& GetStyle() { return style_; }
 
     static std::string GetActiveComponentID() { return state_.componentID.active; }
@@ -140,6 +141,7 @@ private: /// メンバ変数
 
     static NiUIIO           io_;
     static NiUICoreState    state_;
+    static NiUISetting      setting_;
     static NiUIStyle        style_;
 
     // 入力データ
@@ -197,7 +199,8 @@ private: /// その他
     static void SavePreData();
     static void CopyInputData();
     static void ClampRect(NiVec2& _leftTop, const NiVec2& _size, const NiVec2& _parentPos, const NiVec2& _parentSize);
-    static void OffsetUpdate(const std::string& _id, const NiVec2& _originLeftTop, const NiUI_Transform2dEx& _transform, NiVec2& _offset); 
+    static void OffsetUpdate(const std::string& _id, const NiVec2& _originLeftTop, const NiUI_Transform2dEx& _transform, NiVec2& _offset);
+    static void SetComponentId(const NiUI_InputState& _inputState, const std::string& _id, const std::string& _type);
 
 
 public:

--- a/GameProject/NiUI/Type/NiUI_Type_Component.h
+++ b/GameProject/NiUI/Type/NiUI_Type_Component.h
@@ -25,8 +25,7 @@ struct FlexContainerData
 };
 
 
-// ボタンデータ
-struct ButtonData
+struct BaseDrawData
 {
     std::string id;
     std::string textureName;
@@ -35,15 +34,14 @@ struct ButtonData
     uint32_t zOrder;
 };
 
-struct BaseRegionData
+// ボタンデータ
+struct ButtonData : public BaseDrawData
 {
-    std::string id;
-    std::string textureName;
-    NiVec4 color;
-    NiVec2 leftTop;
-    NiVec2 size;
-    uint32_t zOrder;
+};
 
+struct BaseRegionData : public BaseDrawData
+{
+    NiVec4 color;
     BaseRegionData* parent = nullptr;
 };
 

--- a/GameProject/NiUI/Type/NiUI_Type_Core.h
+++ b/GameProject/NiUI/Type/NiUI_Type_Core.h
@@ -1,16 +1,22 @@
 #pragma once
 
 #include <string> // std::string
+#include <unordered_map> // std::unordered_map
 
 #include "../Math/NiVec2.h" // NiVec2
 #include "../Math/NiVec4.h" // NiVec4
 #include "NiUI_Type_Component.h"
 
+using NiID = unsigned int;
+
+template <typename T>
+using StringMap = std::unordered_map<std::string, T>;
 
 // Included in NiUICoreState
 struct NiUIComponentID
 {
-    std::string type;
+    std::string typeHover;
+    std::string typeActive;
     std::string active;
     std::string hover;
     std::string preHover;
@@ -43,6 +49,8 @@ struct NiUIBuffer
     BaseRegionData* currentRegion;
     uint32_t currentZOrder;
     NiVec2 currentPos;
+    BaseDrawData* currentDrawData;
+    StringMap<std::string> areaToItem;
 };
 
 // Included in NiUIIO
@@ -104,4 +112,9 @@ struct NiUICoreState
     NiUIFlags flags;
     NiUITime time;
     NiUIBuffer buffer;
+};
+
+struct NiUISetting
+{
+    int deleteElementThreshold;
 };

--- a/GameProject/Timer/Timer.h
+++ b/GameProject/Timer/Timer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
 class Timer

--- a/GameProject/imgui.ini
+++ b/GameProject/imgui.ini
@@ -19,10 +19,10 @@ Size=305,68
 Collapsed=0
 
 [Window][Player]
-Pos=1167,72
-Size=388,413
+Pos=1212,0
+Size=388,719
 Collapsed=0
-DockId=0x00000001,1
+DockId=0x00000003,1
 
 [Window][Camera]
 Pos=420,54
@@ -35,32 +35,34 @@ Size=162,237
 Collapsed=1
 
 [Window][NiUI_DebugInfo]
-Pos=1167,72
-Size=388,413
+Pos=1212,0
+Size=388,719
 Collapsed=0
-DockId=0x00000001,0
+DockId=0x00000003,0
 
 [Window][Chain Debug]
-Pos=1167,72
-Size=388,413
+Pos=1212,0
+Size=388,719
 Collapsed=0
-DockId=0x00000001,2
+DockId=0x00000003,2
 
 [Window][Terrain]
-Pos=1167,72
-Size=388,413
+Pos=1212,0
+Size=388,719
 Collapsed=0
-DockId=0x00000001,3
+DockId=0x00000003,3
 
 [Window][EnemyManager]
-Pos=1373,4
-Size=92,64
+Pos=1212,721
+Size=388,179
 Collapsed=0
+DockId=0x00000002,2
 
 [Window][Boss]
-Pos=1264,3
-Size=99,63
+Pos=1212,721
+Size=388,179
 Collapsed=0
+DockId=0x00000002,1
 
 [Window][Directional Light]
 Pos=410,84
@@ -72,7 +74,22 @@ Pos=0,0
 Size=1600,900
 Collapsed=0
 
+[Window][LvUP]
+Pos=1217,93
+Size=388,413
+Collapsed=0
+DockId=0x00000003,4
+
+[Window][Chain Display]
+Pos=1212,721
+Size=388,179
+Collapsed=0
+DockId=0x00000002,0
+
 [Docking][Data]
-DockNode  ID=0x00000001 Pos=1167,72 Size=388,413 Selected=0x28B4A56B
-DockSpace ID=0xF852211D Window=0xA87D555D Pos=0,0 Size=1600,900 CentralNode=1
+DockSpace     ID=0xF852211D Window=0xA87D555D Pos=0,0 Size=1600,900 Split=X
+  DockNode    ID=0x00000004 Parent=0xF852211D SizeRef=1210,900 CentralNode=1
+  DockNode    ID=0x00000001 Parent=0xF852211D SizeRef=388,900 Split=Y Selected=0xC4F72FF0
+    DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=388,539 Selected=0xC4F72FF0
+    DockNode  ID=0x00000002 Parent=0x00000001 SizeRef=388,134 Selected=0x45E8B5B2
 


### PR DESCRIPTION
## GameProject.vcxproj
- `GameUI\Chain\GUI_Chain.cpp` と `GameUI\Chain\GUI_Chain.h` を追加

## GameProject.vcxproj.filters
- `GameUI\Chain` フィルタを追加し、その中に `GUI_Chain.cpp` と `GUI_Chain.h` を含める

## GameScene.cpp
- `GUI_Chain` の初期化、更新、描画処理を追加

## GameScene.h
- `GUI_Chain` のインクルードとメンバ変数を追加

## Player.cpp
- キー入力 `DIK_C` に対する通知処理を追加

## GUI_LvUP.cpp
- 未使用のインクルードを削除し、`ImGui` 関連のコードを追加

## GUI_LvUP.h
- `ImGui` 関連のメソッドとメンバ変数を追加

## MyGame.cpp
- `NiUI_Debug` の初期化方法を変更

## NiUI_Debug.cpp
- `Setting` のデバッグ表示を追加

## NiUI_Debug.h
- コンストラクタの変更と `SetIO`、`SetState`、`SetSetting` メソッドを追加

## Impl_Button.cpp, Impl_Div.cpp, Impl_DragItem.cpp
- コンポーネントIDの設定処理を `SetComponentId` メソッドに統一

## NiUI.cpp
- `NiUISetting` の初期化と使用を追加
- データクリア時の処理を強化
- `PostProcessComponents` メソッドで `DragItem` のZオーダーを調整する処理を追加
- `PlaySE` メソッドにおいて、`type` のチェックを `typeHover` に変更

## NiUI.h
- `GetSetting` メソッドと `NiUISetting` 型の `setting_` メンバ変数を追加
- `SetComponentId` メソッドを追加

## NiUI_Type_Component.h
- `ButtonData` 構造体が `BaseDrawData` を継承するように変更
- `BaseRegionData` 構造体も `BaseDrawData` を継承するように変更

## NiUI_Type_Core.h
- `#include <unordered_map>` を追加
- `NiUIComponentID` 構造体に `typeHover` と `typeActive` メンバを追加
- `NiUIBuffer` 構造体に `currentDrawData` と `areaToItem` メンバを追加
- `NiUISetting` 構造体を新たに定義

## Timer.h
- `#define WIN32_LEAN_AND_MEAN` を追加

## imgui.ini
- 複数のウィンドウの位置とサイズを変更し、新しいウィンドウ設定を追加

## GUI_Chain.cpp
- 新しいファイルが追加され、`GUI_Chain` クラスの実装が含まれる
- `IObserver` インターフェースを実装し、チェイン画面の表示を管理

## GUI_Chain.h
- 新しいファイルが追加され、`GUI_Chain` クラスの宣言が含まれる