### PR TITLE
change: ゲームシーンのHUDとスレッドプールの修正

### DIFF
--- a/GameProject/GameProject.vcxproj.filters
+++ b/GameProject/GameProject.vcxproj.filters
@@ -263,9 +263,11 @@
     <ClCompile Include="GameScene\HUD\StatusHUD.cpp">
       <Filter>GameUI\HUD</Filter>
     </ClCompile>
-    <ClCompile Include="GameScene\HUD\StatusBar.cpp" />
     <ClCompile Include="NiGui\NiVec4.cpp">
       <Filter>NiGui</Filter>
+    </ClCompile>
+    <ClCompile Include="GameScene\HUD\StatusBar.cpp">
+      <Filter>GameUI\HUD</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/GameProject/GameScene/GameScene.cpp
+++ b/GameProject/GameScene/GameScene.cpp
@@ -105,6 +105,7 @@ void GameScene::Initialize()
     // StatusHUDの初期化
     statusHUD_ = std::make_unique<StatusHUD>();
     statusHUD_->Initialize();
+    statusHUD_->GetHpBar()->SetMaxValue(player_->getStatus().getMaxHp());
 }
 
 void GameScene::Finalize()
@@ -138,7 +139,6 @@ void GameScene::Update()
     boss_->Update();
     eventTimer_->Measure("Update EnemyManager", [&]() { enemyManager_->Update(); });
     eventTimer_->Measure("Update Minimap", [&]() { minimap_->Update(); });
-    //eventTimer_->Measure("Update CollisionManager", [&]() { pCollisionManager_->Update(); });
 
     /// タイマーの更新
     if (timeKeeper_->GetRemainTime("JunbiPhase") < 3.0f && !countDown_->IsStart())
@@ -150,18 +150,14 @@ void GameScene::Update()
     countDown_->Update();
 
     statusHUD_->Update();
-    //threadpool_->AddTask([&]{pCollisionManager_->Detect(); });
-    //eventTimer_->Measure("ProcessEvent", [&]{threadpool_->AddTask([&]{ pCollisionManager_->ProcessEvents(); }); });
     pCollisionManager_->Detect();
     pCollisionManager_->ProcessEvent();
+
+    *(statusHUD_->GetHpBar()) = player_->getStatus().getHp();
 }
 
 void GameScene::Draw()
 {
-    //Draw2D::GetInstance()->DrawGrid(100.0f, 20.0f, Vector4(1.0f, 1.0f, 1.0f, 1.0f));
-    //Draw2D::GetInstance()->Draw();
-    //Draw2D::GetInstance()->Reset();
-
     //------------------背景Spriteの描画------------------//
     // スプライト共通描画設定
     SpriteBasic::GetInstance()->SetCommonRenderSetting();

--- a/GameProject/GameScene/HUD/StatusHUD.h
+++ b/GameProject/GameScene/HUD/StatusHUD.h
@@ -29,6 +29,8 @@ public:
     void Draw2D();
     void ImGui();
 
+    StatusBar* GetHpBar() { return hpBar_.get(); }
+
 private:
     GlobalVariables* globalVariables_ = nullptr;
     TextureManager* textureManager_ = nullptr;

--- a/GameProject/MyGame/MyGame.cpp
+++ b/GameProject/MyGame/MyGame.cpp
@@ -81,10 +81,6 @@ void MyGame::Initialize()
 
     /// EventTimerの初期化
     eventTimer_ = EventTimer::GetInstance();
-
-    /// Threadpoolの初期化
-    threadpool_ = Threadpool::GetInstance();
-    threadpool_->Initialize(3);
 }
 
 void MyGame::Finalize()

--- a/GameProject/MyGame/MyGame.h
+++ b/GameProject/MyGame/MyGame.h
@@ -55,7 +55,6 @@ private: // メンバ変数
     std::unique_ptr<NiGuiDebug> niguiDebug_ = nullptr;
 
     EventTimer* eventTimer_ = nullptr;
-    Threadpool* threadpool_ = nullptr;
 
     enum PostEffectType
     {

--- a/GameProject/imgui.ini
+++ b/GameProject/imgui.ini
@@ -123,10 +123,7 @@ DockSpace           ID=0xF852211D Window=0xA87D555D Pos=0,0 Size=1600,900 Split=
         DockNode    ID=0x00000007 Parent=0x00000005 SizeRef=388,509 Split=Y Selected=0x86600921
           DockNode  ID=0x00000009 Parent=0x00000007 SizeRef=482,46 HiddenTabBar=1 Selected=0x6108FA95
           DockNode  ID=0x0000000A Parent=0x00000007 SizeRef=482,461 Selected=0x3A93B30B
-        DockNode    ID=0x00000008 Parent=0x00000005 SizeRef=388,65 Selected=0x3D8ECD35
+        DockNode    ID=0x00000008 Parent=0x00000005 SizeRef=388,65 Selected=0x455982C3
       DockNode      ID=0x00000006 Parent=0x00000003 SizeRef=388,129 Selected=0x28B4A56B
     DockNode        ID=0x00000002 Parent=0x00000001 SizeRef=388,191 Selected=0x45E8B5B2
-        DockNode    ID=0x00000008 Parent=0x00000005 SizeRef=388,65 Selected=0x455982C3
-      DockNode      ID=0x00000006 Parent=0x00000003 SizeRef=388,129 Selected=0x11D7DE2D
-    DockNode        ID=0x00000002 Parent=0x00000001 SizeRef=388,191 Selected=0x79329BF2
 


### PR DESCRIPTION
## GameProject.vcxproj.filters
- `GameScene\HUD\StatusBar.cpp` のフィルターを `GameUI\HUD` に変更

## GameScene.cpp
### Initialize()
- `statusHUD_->GetHpBar()->SetMaxValue(player_->getStatus().getMaxHp());` を追加

### Update()
- コメントアウトされていた `pCollisionManager_->Update()` の呼び出しを削除
- `statusHUD_->Update();` の後に `*(statusHUD_->GetHpBar()) = player_->getStatus().getHp();` を追加
- コメントアウトされていた `threadpool_->AddTask([&]{pCollisionManager_->Detect(); });` と `eventTimer_->Measure("ProcessEvent", [&]{threadpool_->AddTask([&]{ pCollisionManager_->ProcessEvents(); }); });` を削除

### Draw()
- コメントアウトされていた `Draw2D::GetInstance()->DrawGrid(100.0f, 20.0f, Vector4(1.0f, 1.0f, 1.0f, 1.0f));`、`Draw2D::GetInstance()->Draw();`、および `Draw2D::GetInstance()->Reset();` を削除

## StatusHUD.h
- `public` セクションに `StatusBar* GetHpBar() { return hpBar_.get(); }` を追加

## MyGame.cpp
### Initialize()
- `Threadpool` の初期化コードを削除

## MyGame.h
- `Threadpool* threadpool_ = nullptr;` を削除

## imgui.ini
- `DockNode` の `Selected` 属性の値を変更
- 一部の `DockNode` エントリを削除し、新しいエントリを追加