### PR TITLE
各エネミーのコライダーに所有者設定を追加

### DIFF
--- a/GameProject/GameScene/Object/Enemy/BounceEnemy.cpp
+++ b/GameProject/GameScene/Object/Enemy/BounceEnemy.cpp
@@ -26,6 +26,7 @@ void BounceEnemy::Initialize()
     collider_->AddIgnore(static_cast<uint32_t>(Collider::Type::ENEMY));
     collider_->AddIgnore(static_cast<uint32_t>(Collider::Type::STAGE));
     collider_->SetSize(1.f);
+    collider_->SetOwner(this);
 }
 
 void BounceEnemy::Update()

--- a/GameProject/GameScene/Object/Enemy/FlyEnemy.cpp
+++ b/GameProject/GameScene/Object/Enemy/FlyEnemy.cpp
@@ -29,6 +29,7 @@ void FlyEnemy::Initialize()
         ->AddIgnore(static_cast<uint32_t>(Collider::Type::STAGE))
         ->SetTranslate(Adaptor(transform_.translate))
         ->SetSize(1.f)
+        ->SetOwner(this)
         ->Enable();
 }
 


### PR DESCRIPTION
`BounceEnemy::Initialize` と `FlyEnemy::Initialize` において、`collider_->SetOwner(this);` を追加しました。
この変更により、各エネミーのコライダーが自身の所有者を正しく認識できるようになり、コライダーのイベント処理や関連ロジックがより適切に動作するようになります。