### PR TITLE
feat: リザルトシーンにEnterキーでタイトル遷移機能を追加

### DIFF
--- a/GameProject/ResultScene/ResultScene.cpp
+++ b/GameProject/ResultScene/ResultScene.cpp
@@ -1,5 +1,8 @@
 #include "ResultScene.h"
 
+#include <Input.h>
+#include <SceneManager.h>
+
 void ResultScene::Initialize()
 {
 }
@@ -10,6 +13,10 @@ void ResultScene::Finalize()
 
 void ResultScene::Update()
 {
+    if (Input::GetInstance()->TriggerKey(DIK_RETURN))
+    {
+        SceneManager::GetInstance()->ChangeScene("title");
+    }
 }
 
 void ResultScene::Draw()


### PR DESCRIPTION
## ResultScene.cpp
- `#include` に以下を追加:
  - `Input.h`
  - `SceneManager.h`
- `ResultScene::Update` メソッドに以下の処理を追加:
  - `Input` クラスの `TriggerKey` メソッドを使用し、`DIK_RETURN` (Enterキー) が押されたかを判定。
  - Enterキーが押された場合、`SceneManager` クラスの `ChangeScene` メソッドを呼び出し、シーンを "title" に変更する処理を実装。