### PR TITLE
change: リザルトシーンのトリガーキーをEnterからSpaceに変更

### DIFF
--- a/GameProject/ResultScene/ResultScene.cpp
+++ b/GameProject/ResultScene/ResultScene.cpp
@@ -13,7 +13,7 @@ void ResultScene::Finalize()
 
 void ResultScene::Update()
 {
-    if (Input::GetInstance()->TriggerKey(DIK_RETURN))
+    if (Input::GetInstance()->TriggerKey(DIK_SPACE))
     {
         SceneManager::GetInstance()->ChangeScene("title");
     }


### PR DESCRIPTION
## 概要
`ResultScene::Finalize` メソッド内で、シーン遷移のトリガーキーを変更しました。

## 変更内容
### `ResultScene.cpp`
- `Input::GetInstance()->TriggerKey` の引数を以下のように変更しました。
  - **変更前**: `DIK_RETURN` (Enterキー)
  - **変更後**: `DIK_SPACE` (スペースキー)
- この変更により、リザルトシーンからタイトルシーンへの遷移トリガーが Enterキーからスペースキーに変更されました。

## 備考
- 他のファイルやバイナリファイルへの影響はありません。