### PR TITLE
feat: Player::Initialize()に特定条件で通知処理を追加

### DIFF
--- a/GameProject/GameScene/Object/Player/Player.cpp
+++ b/GameProject/GameScene/Object/Player/Player.cpp
@@ -62,6 +62,13 @@ void Player::Initialize()
 
 void Player::Update()
 {
+    if (deltaTime_ == 0.0f)
+    {
+        for (auto observer : observers_)
+        {
+            observer->OnNotify("toggle_lvup");
+        }
+    }
     deltaTime_ = DeltaTimeManager::GetInstance()->GetDeltaTime(0);
 
     UpdateInputCommands();


### PR DESCRIPTION
## Playerクラス
- `Player::Initialize()` メソッド内に、`deltaTime_` が `0.0f` の場合に特定の処理を実行するコードを追加。
  - `observers_` リスト内の各オブザーバーに対して `OnNotify("toggle_lvup")` を呼び出す処理を実装。
  - この変更により、`deltaTime_` がゼロの場合に特定の通知イベント（"toggle_lvup"）がトリガーされるように。

## その他
- バイナリファイルやJSONファイルの変更はなし。