### PR TITLE
update: ResultSceneに共通レンダリング設定を適用

### DIFF
--- a/GameProject/ResultScene/ResultScene.cpp
+++ b/GameProject/ResultScene/ResultScene.cpp
@@ -2,6 +2,7 @@
 
 #include <Input.h>
 #include <SceneManager.h>
+#include <SpriteBasic.h>
 
 void ResultScene::Initialize()
 {
@@ -25,6 +26,7 @@ void ResultScene::Update()
 
 void ResultScene::Draw()
 {
+    SpriteBasic::GetInstance()->SetCommonRenderSetting();
     press_->Draw();
 }
 


### PR DESCRIPTION
## 概要
`ResultScene` クラスにおいて、描画時に共通のレンダリング設定を適用するための変更を行いました。

## 変更内容
### `ResultScene.cpp`
- `#include <SpriteBasic.h>` を追加。
  - `SpriteBasic` クラスを使用可能にするためのインクルードを追加しました。

### `ResultScene::Draw()`
- `SpriteBasic::GetInstance()->SetCommonRenderSetting();` を追加。
  - 描画時に共通のレンダリング設定を適用する処理を追加しました。

## 備考
- バイナリファイルやJSONファイルの変更はありません。