### PR TITLE
change: カメラ操作とデバッグオブジェクトの仕様変更

### DIFF
--- a/GameProject/GameScene/GameScene.cpp
+++ b/GameProject/GameScene/GameScene.cpp
@@ -51,6 +51,7 @@ void GameScene::Initialize()
     freeLookCamera_ = std::make_unique<FreeLookCamera>();
     freeLookCamera_->Initialize();
     //Object3dBasic::GetInstance()->SetCamera(freeLookCamera_->GetCamera());
+    //Draw2D::GetInstance()->SetCamera(freeLookCamera_->GetCamera());
 
     // ChainViewModel
     chainViewModel_ = std::make_unique<ChainViewModel>();

--- a/GameProject/GameScene/Object/Camera/FollowCamera.cpp
+++ b/GameProject/GameScene/Object/Camera/FollowCamera.cpp
@@ -21,10 +21,15 @@ void FollowCamera::Initialize()
         ->SetType(Collision::Type::Ray);
 
     // Debug
-    pDebugObject_ = std::make_unique<Object3d>();
-    pDebugObject_->Initialize();
-    pDebugObject_->SetModel("box.gltf");
-    pDebugObject_->SetScale({ 0.1f, 0.1f, 0.1f });
+    pDebugObjectCamera_ = std::make_unique<Object3d>();
+    pDebugObjectCamera_->Initialize();
+    pDebugObjectCamera_->SetModel("box.gltf");
+    pDebugObjectCamera_->SetScale({ 0.5f, 0.5f, 0.5f });
+
+    pDebugObjectHitPoint_ = std::make_unique<Object3d>();
+    pDebugObjectHitPoint_->Initialize();
+    pDebugObjectHitPoint_->SetModel("box.gltf");
+    pDebugObjectHitPoint_->SetScale({ 0.1f, 0.1f, 0.1f });
 }
 
 void FollowCamera::Update()
@@ -53,10 +58,12 @@ void FollowCamera::Update()
     if (otherCollider)
     {
         pCamera_->SetTranslate(Adaptor(hitData.hitPoint));
+        pDebugObjectHitPoint_->SetTranslate(Adaptor(hitData.hitPoint));
     }
     else
     {
         pCamera_->SetTranslate(nextCameraPosition);
+        pDebugObjectHitPoint_->SetTranslate(nextCameraPosition);
     }
 
     pCamera_->SetRotate(rotate);
@@ -64,9 +71,13 @@ void FollowCamera::Update()
 
     targetPositionPre_ = nextTargetPosition;
 
-    pDebugObject_->SetRotate(rotate);
-    pDebugObject_->SetTranslate(nextCameraPosition);
-    pDebugObject_->Update();
+    pDebugObjectCamera_->SetRotate(rotate);
+    pDebugObjectCamera_->SetTranslate(nextCameraPosition);
+    pDebugObjectCamera_->Update();
+
+    pDebugObjectHitPoint_->SetRotate(rotate);
+    pDebugObjectHitPoint_->Update();
+
 }
 
 void FollowCamera::Finalize()
@@ -75,7 +86,8 @@ void FollowCamera::Finalize()
 
 void FollowCamera::Draw3D()
 {
-    pDebugObject_->Draw();
+    //pDebugObjectCamera_->Draw();
+    //pDebugObjectHitPoint_->Draw();
 }
 
 void FollowCamera::Draw2D()

--- a/GameProject/GameScene/Object/Camera/FollowCamera.h
+++ b/GameProject/GameScene/Object/Camera/FollowCamera.h
@@ -25,7 +25,8 @@ class FollowCamera
     Collision::Manager* pCollisionManager_ = nullptr;
 
     // for debug
-    std::unique_ptr<Object3d> pDebugObject_ = nullptr;
+    std::unique_ptr<Object3d> pDebugObjectCamera_ = nullptr;
+    std::unique_ptr<Object3d> pDebugObjectHitPoint_ = nullptr;
 
 public:
     void Initialize();

--- a/GameProject/GameSystem/FreeCamera/FreeLookCamera.cpp
+++ b/GameProject/GameSystem/FreeCamera/FreeLookCamera.cpp
@@ -24,11 +24,12 @@ void FreeLookCamera::Update()
     prevCursorPos_ = currCursorPos_;
     GetCursorPos(&currCursorPos_);
 
-    if(pInput_->PushMouse(1))
+    this->CatchMoveCommands();
+    if (pInput_->PushMouse(1))
     {
-        this->CatchMoveCommands();
         this->CatchRotateCommands();
     }
+
 
     pCamera_->Update();
 }
@@ -45,32 +46,40 @@ void FreeLookCamera::CatchMoveCommands()
     NiVec3 right = FMath::RotateVector({ 1.0f, 0.0f, 0.0f }, rotate_);
 
     /// 向いている方向に移動
-    if(pInput_->PushKey(DIK_W))
+    if (pInput_->PushKey(DIK_RSHIFT))
+    {
+        moveSpeed_ = 0.5f;
+    }
+    else
+    {
+        moveSpeed_ = 0.1f;
+    }
+    if(pInput_->PushKey(DIK_I))
     {
         NiVec3 cameraPosition = NiUtil::Adaptor(pCamera_->GetTranslate()) + forward * moveSpeed_;
         pCamera_->SetTranslate(NiUtil::Adaptor(cameraPosition));
     }
-    if(pInput_->PushKey(DIK_S))
+    if(pInput_->PushKey(DIK_K))
     {
         NiVec3 cameraPosition = NiUtil::Adaptor(pCamera_->GetTranslate()) - forward * moveSpeed_;
         pCamera_->SetTranslate(NiUtil::Adaptor(cameraPosition));
     }
-    if(pInput_->PushKey(DIK_A))
+    if(pInput_->PushKey(DIK_J))
     {
         NiVec3 cameraPosition = NiUtil::Adaptor(pCamera_->GetTranslate()) - right * moveSpeed_;
         pCamera_->SetTranslate(NiUtil::Adaptor(cameraPosition ));
     }
-    if(pInput_->PushKey(DIK_D))
+    if(pInput_->PushKey(DIK_L))
     {
         NiVec3 cameraPosition = NiUtil::Adaptor(pCamera_->GetTranslate()) + right * moveSpeed_;
         pCamera_->SetTranslate(NiUtil::Adaptor(cameraPosition));
     }
-    if(pInput_->PushKey(DIK_Q))
+    if(pInput_->PushKey(DIK_U))
     {
         NiVec3 cameraPosition = NiUtil::Adaptor(pCamera_->GetTranslate()) + NiVec3(0.0f, -moveSpeed_, 0.0f);
         pCamera_->SetTranslate(NiUtil::Adaptor(cameraPosition));
     }
-    if(pInput_->PushKey(DIK_E))
+    if(pInput_->PushKey(DIK_O))
     {
         NiVec3 cameraPosition = NiUtil::Adaptor(pCamera_->GetTranslate()) + NiVec3(0.0f, moveSpeed_, 0.0f);
         pCamera_->SetTranslate(NiUtil::Adaptor(cameraPosition));


### PR DESCRIPTION
### `GameScene::Initialize`
- `Draw2D::GetInstance()->SetCamera(freeLookCamera_->GetCamera());`をコメントアウト。

### `FollowCamera`
- デバッグ用オブジェクト`pDebugObject_`を削除。
- 新たに`pDebugObjectCamera_`と`pDebugObjectHitPoint_`を追加。
  - `pDebugObjectCamera_`のスケールを`{0.5f, 0.5f, 0.5f}`に設定。
  - `pDebugObjectHitPoint_`のスケールを`{0.1f, 0.1f, 0.1f}`に設定。

#### `FollowCamera::Initialize`
- 上記のデバッグオブジェクトの初期化処理を追加。

#### `FollowCamera::Update`
- 衝突判定の結果に基づき、`pDebugObjectHitPoint_`の位置を更新。
- `pDebugObject_`の更新処理を削除し、`pDebugObjectCamera_`と`pDebugObjectHitPoint_`の更新処理を追加。

#### `FollowCamera::Draw3D`
- `pDebugObject_->Draw()`を削除。
- `pDebugObjectCamera_`と`pDebugObjectHitPoint_`の描画処理をコメントアウト。

### `FreeLookCamera`
#### `FreeLookCamera::Initialize`
- `this->CatchMoveCommands();`の呼び出し位置を変更。
  - `if (pInput_->PushMouse(1))`の条件内から外に移動。

#### `FreeLookCamera::CatchMoveCommands`
- 移動速度`moveSpeed_`を`DIK_RSHIFT`キーの押下状態に応じて`0.5f`または`0.1f`に設定。
- カメラ移動のキー操作を以下のようにリマップ：
  - 前進: `DIK_W` → `DIK_I`
  - 後退: `DIK_S` → `DIK_K`
  - 左移動: `DIK_A` → `DIK_J`
  - 右移動: `DIK_D` → `DIK_L`
  - 下移動: `DIK_Q` → `DIK_U`
  - 上移動: `DIK_E` → `DIK_O`