### PR TITLE
change: DeltaTimeManagerの使用を改善

### DIFF
--- a/GameProject/GameScene/Object/Player/Player.cpp
+++ b/GameProject/GameScene/Object/Player/Player.cpp
@@ -78,13 +78,11 @@ void Player::Initialize()
         for (auto& obs : observers_)
         {
             obs->OnNotify("toggle_lvup");
-            DeltaTimeManager::GetInstance()->SetDeltaTime(1, 0.0f);
         }
     });
 
     id_callback_chainconfirm_ = GameEventNotifier::GetInstance()->RegisterCallback("ChainConfirm", [this]([[maybe_unused]]std::any _unused) {
         this->OnChainConfirm();
-        DeltaTimeManager::GetInstance()->SetDeltaTime(1, 1.0f / 60.0f);
     });
 
 }

--- a/GameProject/GameUI/Chain/GUI_Chain.cpp
+++ b/GameProject/GameUI/Chain/GUI_Chain.cpp
@@ -14,20 +14,22 @@ void GUI_Chain::Initialize()
 
 void GUI_Chain::OnNotify(const std::string& _event)
 {
+    auto dtm = DeltaTimeManager::GetInstance();
     if (_event == "open_chain")
     {
+        dtm->SetDeltaTime(1, 0.0f);
         isDisplay_ = true;
     }
     else if (_event == "close_chain")
     {
+        dtm->SetDeltaTime(1, 1.0f / 60.0f);
         isDisplay_ = false;
     }
     else if (_event == "toggle_chain")
     {
-        auto dtm = DeltaTimeManager::GetInstance();
-        isDisplay_ = !isDisplay_;
-        if (dtm->GetDeltaTime(1) == 0.0f) dtm->SetDeltaTime(1, 1.0f / 60.0f);
+        if (isDisplay_) dtm->SetDeltaTime(1, 1.0f / 60.0f);
         else dtm->SetDeltaTime(1, 0.0f);
+        isDisplay_ = !isDisplay_;
     }
 }
 

--- a/GameProject/GameUI/LvUP/GUI_LvUP.cpp
+++ b/GameProject/GameUI/LvUP/GUI_LvUP.cpp
@@ -7,6 +7,7 @@
 #include <imgui.h>
 #include <WinApp.h>
 #include <Utility/Adaptor.h>
+#include <GameSystem/DeltaTimeManager/DeltaTimeManager.h>
 
 void GUI_LvUP::Initialize()
 {
@@ -59,16 +60,21 @@ void GUI_LvUP::Initialize()
 
 void GUI_LvUP::OnNotify(const std::string& _event)
 {
+    auto dtm = DeltaTimeManager::GetInstance();
     if (_event == "open_lvup")
     {
+        dtm->SetDeltaTime(1, 0.0f);
         isDisplay_ = true;
     }
     else if (_event == "close_lvup")
     {
+        dtm->SetDeltaTime(1, 1.0f / 60.0f);
         isDisplay_ = false;
     }
     else if (_event == "toggle_lvup")
     {
+        if (isDisplay_) dtm->SetDeltaTime(1, 1.0f / 60.0f);
+        else dtm->SetDeltaTime(1, 0.0f);
         isDisplay_ = !isDisplay_;
     }
 }
@@ -93,6 +99,7 @@ void GUI_LvUP::Update()
         gameController_->HandleConfirmCard(selectedCard_);
         isSelected_ = false;
         isPickRandom_ = false;
+        DeltaTimeManager::GetInstance()->SetDeltaTime(1, 1.0f / 60.0f);
     }
 }
 

--- a/GameProject/imgui.ini
+++ b/GameProject/imgui.ini
@@ -371,6 +371,46 @@ Pos=60,60
 Size=319,127
 Collapsed=0
 
+[Window][ff1310c1-e056-4464-96de-95ccf0eeab15]
+Pos=60,60
+Size=319,127
+Collapsed=0
+
+[Window][6d8e6495-b01e-4c2a-99f8-f7ae0f7360ca]
+Pos=60,60
+Size=319,127
+Collapsed=0
+
+[Window][65ae3577-9712-4924-8836-0978e7d641f2]
+Pos=60,60
+Size=319,127
+Collapsed=0
+
+[Window][80c5edaf-5878-4001-93e4-75c4d5f260f2]
+Pos=60,60
+Size=319,127
+Collapsed=0
+
+[Window][1b63befd-96a8-4501-9d4b-73f12a13ddc3]
+Pos=60,60
+Size=319,127
+Collapsed=0
+
+[Window][69b9dd8b-5f5a-460a-aa22-e66ea107c05d]
+Pos=60,60
+Size=319,127
+Collapsed=0
+
+[Window][2ea25a53-3a16-4431-9c0b-9c95701538a9]
+Pos=60,60
+Size=319,127
+Collapsed=0
+
+[Window][94380444-ab94-4db8-874d-d30e07a1e9b3]
+Pos=60,60
+Size=319,127
+Collapsed=0
+
 [Docking][Data]
 DockNode              ID=0x0000000C Pos=112,212 Size=227,623 Split=Y
   DockNode            ID=0x0000000D Parent=0x0000000C SizeRef=227,436 Selected=0x3CB0ABD0


### PR DESCRIPTION
* Player.cpp
  - `Player::Initialize()`メソッドで、`DeltaTimeManager::GetInstance()->SetDeltaTime`の呼び出しを削除し、コールバックを`GameEventNotifier`を通じて登録。

* GUI_Chain.cpp
  - `GUI_Chain::OnNotify()`メソッドに`DeltaTimeManager`のインスタンス取得を追加し、イベントに応じたデルタタイムの設定を簡略化。

* GUI_LvUP.cpp
  - `GUI_LvUP::OnNotify()`メソッドで`DeltaTimeManager`のインスタンス取得を追加し、`open_lvup`および`close_lvup`イベントに対するデルタタイム設定を実装。
  - `Update()`メソッドに選択時のデルタタイム設定を追加。

* imgui.ini
  - 複数のウィンドウ設定を追加し、UIのレイアウトを改善。