### PR TITLE
ポストエフェクトとライト設定の更新

### DIFF
--- a/GameProject/GameScene/GameScene.cpp
+++ b/GameProject/GameScene/GameScene.cpp
@@ -24,15 +24,17 @@ void GameScene::Initialize()
 
     //ModelManager::GetInstance()->GetModel("rocketBullet.gltf");
 
-    PostEffect::GetInstance()->SetEffectType("NoEffect");
+    PostEffect::GetInstance()->SetEffectType("RGBSplit");
+    PostEffect::GetInstance()->SetRGBSplitIntensity(0.2f);
 
     // ステージデータの取得
     const auto& currentStageData = StageManager::GetInstance()->GetCurrentStageData();
 
     
     directLightParam_ = {
-        .direction = { 0.0f, -1.0f, 0.0f },
-        .color = {1.000f, 0.254f, 0.254f, 1.000f},
+        .direction = { .x= 0.0f, .y= -1.0f, .z= 0.0f },
+        //.color = {1.000f, 0.254f, 0.254f, 1.000f},
+        .color = {.x= 1.000f, .y= 1.0f, .z= 1.0f, .w= 1.000f},
         .lightType = 1,
         .intensity = 2.0f
     };
@@ -251,6 +253,15 @@ void GameScene::Finalize()
 
 void GameScene::Update()
 {
+    if (boss_->GetIsValid())
+    {
+        directLightParam_.color = { .x= 1.0f, .y= 0.254f, .z= 0.254f, .w= 1.0f };
+    }
+    else
+    {
+        directLightParam_.color = { .x= 1.0f, .y= 1.0f, .z= 1.0f, .w= 1.0f };
+    }
+
     Object3dBasic::GetInstance()->SetDirectionalLight(directLightParam_.direction, directLightParam_.color, directLightParam_.lightType, directLightParam_.intensity);
     ReinforcementManager::GetInstance()->Update();
     this->UpdateInputCommands();


### PR DESCRIPTION
`GameScene::Initialize` メソッドでポストエフェクトのタイプを "NoEffect" から "RGBSplit" に変更し、RGB分割の強度を 0.2f に設定しました。`directLightParam_` の `direction` フィールドの初期化方法を変更し、`color` フィールドの値を新しい値に更新しました。

`GameScene::Update` メソッドを追加し、ボスの有効/無効に応じて `directLightParam_.color` の値を変更しました。ボスが有効な場合は赤色、無効な場合は白色に設定され、方向性ライトの設定が行われるようになりました。