### PR TITLE
change: エイムモードのカーソル表示制御を改善

### DIFF
--- a/GameProject/GameScene/Object/Player/Player.cpp
+++ b/GameProject/GameScene/Object/Player/Player.cpp
@@ -448,16 +448,22 @@ void Player::ChangeAimModeForce(bool _isMouseAim)
 {
     if (_isMouseAim)
     {
-        countCursorVisible_ = 0;
         SetCursorPos(ORIGIN.x, ORIGIN.y);
-        ShowCursor(false);
+        while (countCursorVisible_ > 0)
+        {
+            --countCursorVisible_;
+            ShowCursor(false);
+        }
         mouseAim_ = true;
     }
     else
     {
-        countCursorVisible_ = 1;
         SetCursorPos(ORIGIN.x, ORIGIN.y);
-        ShowCursor(true);
+        while (countCursorVisible_ < 1)
+        {
+            ++countCursorVisible_;
+            ShowCursor(true);
+        }
         mouseAim_ = false;
     }
 }

--- a/GameProject/GameScene/Object/Player/Player.h
+++ b/GameProject/GameScene/Object/Player/Player.h
@@ -66,7 +66,7 @@ private:
     int         countCursorVisible_ = 1;
 
     // 特殊なステータス
-    with_initial<uint32_t>    numAbleJump_        = 2;        // ジャンプ可能回数
+    with_initial<uint32_t>    numAbleJump_        = 1;        // ジャンプ可能回数
 
 
 public:

--- a/GameProject/GameUI/Chain/wnd_chain.cpp
+++ b/GameProject/GameUI/Chain/wnd_chain.cpp
@@ -35,7 +35,6 @@ void GUI_Chain::OnNotify(const std::string& _name, const std::string& _event)
         if (isDisplay_) dtm->SetDeltaTime(1, 1.0f / 60.0f);
         else dtm->SetDeltaTime(1, 0.0f);
         isDisplay_ = !isDisplay_;
-        notifier_->Notify("OnWindowOpen", isDisplay_);
     }
 
     if (isDisplay_ && !preIsDisplay)


### PR DESCRIPTION
* `Player.cpp`
  * `ChangeAimModeForce`関数において、マウスのエイムモードが有効な場合、`countCursorVisible_`が0になるまで`ShowCursor(false)`を呼び出すループを追加。
  * マウスのエイムモードが無効な場合も、`countCursorVisible_`が1になるまで`ShowCursor(true)`を呼び出すループを追加。

* `Player.h`
  * `numAbleJump_`の初期値を2から1に変更し、ジャンプ可能回数を減少。

* `wnd_chain.cpp`
  * `OnNotify`関数から`notifier_->Notify("OnWindowOpen", isDisplay_);`を削除し、ウィンドウのオープン通知を無効化。

バイナリファイルやJSONの変更はありません。